### PR TITLE
Optimize day 1 solution

### DIFF
--- a/hs/src/P01.hs
+++ b/hs/src/P01.hs
@@ -1,17 +1,25 @@
 module P01 where
 
 import Data.Maybe (fromJust)
+import qualified Data.Set as Set
 import Import
 
 solution :: Solution [Int]
 solution = solve (decimal `sepBy` "\n") $ \numbers -> do
-  part1 $ product $ fromJust $ findSum 2 numbers -- 73371
-  part2 $ product $ fromJust $ findSum 3 numbers -- 127642310
+  part1 $ product $ fromJust $ findPair 2020 numbers -- 73371
+  part2 $ product $ fromJust $ findTriple 2020 numbers -- 127642310
 
-findSum :: Int -> [Int] -> Maybe [Int]
-findSum ofSize = find ((== 2020) . sum) . tuples ofSize
+findPair :: Int -> [Int] -> Maybe [Int]
+findPair target = go Set.empty
+  where
+    go seen (a : as) =
+      if (target - a) `Set.member` seen
+        then Just [a, target - a]
+        else go (a `Set.insert` seen) as
+    go _ _ = Nothing
 
-tuples :: Int -> [a] -> [[a]]
-tuples _ [] = []
-tuples 0 _ = [[]]
-tuples n (a : as) = map (a :) (tuples (n - 1) as) ++ tuples n as
+findTriple :: Int -> [Int] -> Maybe [Int]
+findTriple target (a : as) = case findPair (target - a) as of
+  Just ns -> Just (a : ns)
+  _ -> findTriple target as
+findTriple _ _ = Nothing

--- a/hs/test/P01Spec.hs
+++ b/hs/test/P01Spec.hs
@@ -17,7 +17,7 @@ input =
 spec :: Spec
 spec = parallel $ do
   it "can find pairs" $ do
-    findSum 2 input `shouldBe` Just [1721, 299]
+    findPair 2020 input `shouldBe` Just [299, 1721]
 
   it "can find triples" $ do
-    findSum 3 input `shouldBe` Just [979, 366, 675]
+    findTriple 2020 input `shouldBe` Just [979, 675, 366]


### PR DESCRIPTION
Local ∆ of `37.33ms => 586.7 μs`.

Maybe surprisingly, this approach to `findTriple` is ~5x faster than a single-scan index-of-sums approach (though that could be an artifact of the implementation / data set).

# Before

```
time                 37.33 ms   (36.67 ms .. 38.77 ms)
                     0.997 R²   (0.993 R² .. 1.000 R²)
mean                 37.42 ms   (37.14 ms .. 38.00 ms)
std dev              834.2 μs   (400.5 μs .. 1.374 ms)
```

# After

```
time                 586.7 μs   (583.5 μs .. 590.0 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 586.7 μs   (584.8 μs .. 589.5 μs)
std dev              7.341 μs   (5.814 μs .. 10.11 μs)
```