### PR TITLE
Optimize day 9

### DIFF
--- a/hs/src/P09.hs
+++ b/hs/src/P09.hs
@@ -1,17 +1,17 @@
 module P09 where
 
-import Import
-import Data.Sequence (Seq(..), (|>))
+import Data.Sequence (Seq (..), (|>))
 import qualified Data.Sequence as Seq
-
+import Import
+import P01 (findPair)
 
 solution :: Solution (Seq Int)
 solution = solve parser $ \numbers -> do
   let m = scanForNonSum 25 numbers
   part1 m -- Just 70639851
-
-  part2 $ fmap (uncurry (+)) $ -- Just 8249240
-    bounds =<< flip consecutiveSum numbers =<< m
+  part2 $
+    fmap (uncurry (+)) $ -- Just 8249240
+      bounds =<< flip consecutiveSum numbers =<< m
 
 parser :: Parser (Seq Int)
 parser = Seq.fromList <$> decimal `sepBy` "\n"
@@ -19,11 +19,10 @@ parser = Seq.fromList <$> decimal `sepBy` "\n"
 scanForNonSum :: Int -> Seq Int -> Maybe Int
 scanForNonSum size = uncurry go . Seq.splitAt size
   where
-    -- TODO: we can certainly get better asymptotics than this, but the constants
-    --       here are relatively small. Benchmark _then_ optimize.
-    go pre@(_ :<| ps) (a :<| as) = if a `elem` liftA2 (+) pre pre
-      then go (ps |> a) as
-      else Just a
+    go pre@(_ :<| ps) (a :<| as) =
+      if isJust $ findPair a $ toList pre
+        then go (ps |> a) as
+        else Just a
     go _ _ = Nothing
 
 bounds :: Seq Int -> Maybe (Int, Int)
@@ -31,14 +30,16 @@ bounds Empty = Nothing
 bounds (a :<| as) = Just $ foldr (\n -> min n *** max n) (a, a) as
 
 consecutiveSum :: Int -> Seq Int -> Maybe (Seq Int)
-consecutiveSum _ Empty = Nothing
-consecutiveSum target s@(_ :<| ns) = takeSum target s <|> consecutiveSum target ns
-
-takeSum :: Int -> Seq Int -> Maybe (Seq Int)
-takeSum target = go Seq.empty 0
+consecutiveSum target = go Empty 0
   where
-    go _ _ Empty = Nothing
-    go acc total (n :<| ns) = case compare total target of
-      LT -> go (acc |> n) (total + n) ns
+    -- Since this is a list of non-negative integers, we can maintain a sliding
+    -- window which expands right if its sum is too small, and contracts left if
+    -- its sum is too high.
+    go acc total rest = case compare total target of
       EQ -> Just acc
-      GT -> Nothing -- Assuming non-negative integers, we can bail once we're over the target
+      LT -> case rest of
+        (n :<| ns) -> go (acc |> n) (total + n) ns
+        _ -> Nothing
+      GT -> case acc of
+        (a :<| as) -> go as (total - a) rest
+        _ -> Nothing


### PR DESCRIPTION
Local ∆ of 8.499 ms => 824.7 μs through a few changes

* Rather than starting from each element in the list in turn and scanning right, maintain a single sliding window.
* Use a more efficient "is this value a sum of values from the preamble" check. Note that the new implementation does discard some still-relevant pre-computed data step-to-step, so there may still be some juice to squeeze here.

# Before

```
time                 8.499 ms   (7.319 ms .. 9.851 ms)
                     0.919 R²   (0.881 R² .. 0.978 R²)
mean                 8.093 ms   (7.731 ms .. 8.588 ms)
std dev              1.154 ms   (832.1 μs .. 1.438 ms)
```

# After

```
time                 824.7 μs   (811.6 μs .. 841.9 μs)
                     0.996 R²   (0.993 R² .. 0.999 R²)
mean                 836.4 μs   (828.1 μs .. 850.1 μs)
std dev              36.72 μs   (24.88 μs .. 56.24 μs)
```