### PR TITLE
Clean up parsing utilities

### DIFF
--- a/hs/README.md
+++ b/hs/README.md
@@ -5,15 +5,15 @@
 # Commands
 
 ```bash
-$ stack exec aoc run            # run all solutions
-$ stack exec aoc run $n         # run solution #n
-$ stack exec aoc bench          # run all benchmarks
-$ stack exec aoc bench $n       # run benchmarks for solution #n
+$ stack exec aoc run             # run all solutions
+$ stack exec aoc run $n          # run solution #n
+$ stack exec aoc bench           # run all benchmarks
+$ stack exec aoc bench $n        # run benchmarks for solution #n
 $ stack test                     # run unit tests
 $ stack test --fast --file-watch # run unit tests, watching for changes
 $ env CI=true stack test         # run unit and regression tests
-$ stack exec aoc list           # list auto-discovered solutions
-$ stack exec aoc -- --help      # view CLI documentation
+$ stack exec aoc list            # list auto-discovered solutions
+$ stack exec aoc -- --help       # view CLI documentation
 ```
 
 ## Profiling

--- a/hs/src/Import.hs
+++ b/hs/src/Import.hs
@@ -1,14 +1,12 @@
 module Import
   ( module X,
     grid,
-    parse,
     sepBy1,
   )
 where
 
 import Control.Arrow as X ((***), (>>>))
 import Control.Lens ((+=), (.=), _1, _2)
-import Control.Monad.Fail (MonadFail (fail))
 import Data.Attoparsec.Text (Parser, atEnd, endOfInput, endOfLine, many', many1', notChar, parseOnly)
 import Data.Attoparsec.Text as X (Parser, choice, decimal, digit, endOfInput, inClass, parseOnly, sepBy, string)
 import Data.Char as X (isAlpha, isSpace)
@@ -16,11 +14,6 @@ import Data.Grid as X (Grid)
 import Data.String as X (String)
 import Protolude as X
 import Santa.Solution as X (Solution, part1, part2, solve)
-
-parse :: MonadFail m => Parser a -> Text -> m a
-parse parser input = case parseOnly (parser <* optional "\n" <* endOfInput) input of
-  Left err -> fail $ "Failed to parse input: " <> err
-  Right val -> return val
 
 grid :: Parser (Grid Char)
 grid = evalStateT cells (0, 0)

--- a/hs/test/GenericSpec.hs
+++ b/hs/test/GenericSpec.hs
@@ -56,7 +56,7 @@ spec = do
   describe "parse" $
     it "applies a parser to structured input" $
       parse parser (Demo "123" "right")
-        `shouldBe` (Demo (Right 123) (Right "right"))
+        `shouldBe` Demo (Right 123) (Right "right")
 
   describe "parseStruct" $ do
     let run = parseStruct parser . Map.fromList

--- a/hs/test/P06Spec.hs
+++ b/hs/test/P06Spec.hs
@@ -4,7 +4,8 @@ import P06
 import SpecImport
 
 ex :: Text
-ex = [here|abc
+ex =
+  [here|abc
 
 a
 b
@@ -18,7 +19,8 @@ a
 a
 a
 
-b|]
+b
+|]
 
 spec :: Spec
 spec = parallel $ do

--- a/hs/test/SpecImport.hs
+++ b/hs/test/SpecImport.hs
@@ -1,18 +1,28 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module SpecImport
-  ( module X
-  , fromRight
-  , parseRight
-  ) where
 
-import Import       as X hiding (Selector, fromRight)
-import Prelude      (error)
-import Control.Monad.Fail (MonadFail(..))
-import Test.Hspec   as X
+module SpecImport
+  ( module X,
+    fromRight,
+    parse,
+    parseRight,
+  )
+where
+
+import Control.Monad.Fail (MonadFail (..))
+import qualified Data.Text as Text
+import Import as X hiding (Selector, fromRight)
+import qualified Santa.Solution as Santa (parse)
+import Test.Hspec as X
 import Text.Heredoc as X (here)
+import Prelude (error)
 
 instance MonadFail (Either String) where
   fail = Left
+
+parse :: MonadFail m => Parser a -> Text -> m a
+parse p i = case Santa.parse p i of
+  Left err -> fail $ Text.unpack err
+  Right val -> return val
 
 -- A deliberately non-total version of fromRight, to allow for easier matching
 -- in specs
@@ -20,7 +30,8 @@ fromRight :: Either a b -> b
 fromRight = either (\_ -> error "Unexpected left") identity
 
 parseRight :: Parser a -> Text -> a
-parseRight parser input = either
-  (\e -> error $ "Unexpected parse failure " <> e)
-  identity
-  $ parse parser input
+parseRight parser input =
+  either
+    (\e -> error $ "Unexpected parse failure " <> e)
+    identity
+    $ parse parser input

--- a/santa/src/Santa/Runner.hs
+++ b/santa/src/Santa/Runner.hs
@@ -2,17 +2,18 @@ module Santa.Runner
   ( benchAll,
     fmt,
     run,
-  ) where
+  )
+where
 
-import Criterion.Types (Config(..))
 import Criterion.Main
+import Criterion.Types (Config (..))
 import qualified Data.Map as Map
 import qualified Data.Text as Text
 import Protolude
-import Text.Printf (printf)
 import Santa.Problems (Problems)
 import Santa.Solution (Error)
 import System.FilePath.Posix ((</>))
+import Text.Printf (printf)
 
 benchAll :: Problems -> FilePath -> IO ()
 benchAll problems inputs = do
@@ -25,11 +26,12 @@ benchAll problems inputs = do
       contents <- input inputs n
       return $ bench (Text.unpack n) $ nf solution contents
 
-    config = defaultConfig
-      { reportFile = Just "./bench/report.html"
-      , csvFile    = Just "./bench/report.csv"
-      , jsonFile   = Just "./bench/report.json"
-      }
+    config =
+      defaultConfig
+        { reportFile = Just "./bench/report.html",
+          csvFile = Just "./bench/report.csv",
+          jsonFile = Just "./bench/report.json"
+        }
 
 run :: Problems -> FilePath -> Text -> IO (Either Error (Text, Text))
 run problems inputs n = case Map.lookup n problems of

--- a/santa/src/Santa/Solution.hs
+++ b/santa/src/Santa/Solution.hs
@@ -1,6 +1,8 @@
 module Santa.Solution
   ( Solution,
     Error,
+    parse,
+    parse',
     part1,
     part2,
     run,
@@ -10,15 +12,17 @@ where
 
 import Control.Lens
 import Data.Attoparsec.Text (Parser, endOfInput, parseOnly)
-import Data.Text (pack)
+import qualified Data.Attoparsec.Text as Atto
 import Data.Either.Combinators (mapLeft)
+import Data.Text (pack)
 import Protolude
 
 type S = (Text, Text)
 
 newtype SolutionT m a = SolutionT
   { unSolutionT :: StateT S m a
-  } deriving (Functor, Applicative, Monad, MonadState S)
+  }
+  deriving (Functor, Applicative, Monad, MonadState S)
 
 data Solution' m a = Solution
   { parser :: Parser a,
@@ -31,13 +35,24 @@ newtype Error = ParseError Text
   deriving (Show, Eq, NFData)
 
 run :: Solution a -> Text -> Either Error S
-run solution input = runIdentity $ either
-  (return . Left . ParseError)
-  (\parsed -> Right <$> execStateT (unSolutionT $ runner solution parsed) ("", ""))
-  $ parse (parser solution) input
+run solution input =
+  runIdentity $
+    either
+      (return . Left . ParseError)
+      (\parsed -> Right <$> execStateT (unSolutionT $ runner solution parsed) ("", ""))
+      $ parse (parser solution) input
 
 parse :: Parser a -> Text -> Either Text a
-parse p i = mapLeft pack $ parseOnly (p <* optional "\n" <* endOfInput) i
+parse p = mapLeft pack . parseOnly (p <* optional "\n" <* endOfInput)
+
+-- parse' fails with a full description of the unconsumed input
+parse' :: Parser a -> Text -> Either Text a
+parse' p = fmt . Atto.parse (p <* optional "\n")
+  where
+    fmt (Atto.Done "" result) = Right result
+    fmt (Atto.Done rest _) = Left $ "Unconsumed input: " <> rest
+    fmt (Atto.Fail _ _ msg) = Left $ pack msg
+    fmt (Atto.Partial cc) = fmt $ cc ""
 
 solve :: Functor m => Parser a -> (a -> SolutionT m b) -> Solution' m a
 solve p r = Solution p (void . r)


### PR DESCRIPTION
* the `parse` in tests now uses the underlying `Santa.Solution.parse`
* introduces a `parse'` which prints the unconsumed input (currently unused, but helpful in dev)
